### PR TITLE
Prevent memory leak on cleaning up data

### DIFF
--- a/can-dom-data-state.js
+++ b/can-dom-data-state.js
@@ -41,7 +41,7 @@ var setData = function(name, value) {
 			removedDisposalMap[id] = domMutate.onNodeRemoval(target, function () {
 				if (!target.ownerDocument.contains(target)) {
 					setTimeout(function () {
-						deleteNode(target);
+						deleteNode.call(target);
 					}, 13);
 				}
 			});

--- a/test/memory-test.js
+++ b/test/memory-test.js
@@ -9,6 +9,7 @@ unit.test('should clean up data when a node is removed from the document', funct
 	var done = assert.async();
 	var node = document.createElement('div');
 	var slot = document.getElementById('qunit-fixture');
+
 	domDataState.set.call(node, 'foo', 'bar');
 
 	slot.appendChild(node);
@@ -16,7 +17,8 @@ unit.test('should clean up data when a node is removed from the document', funct
 	var dispose = domMutate.onNodeRemoval(node, function () {
 		dispose();
 		setTimeout(function () {
-			assert.equal(domDataState.get(node), undefined, 'Data should be empty');
+			assert.equal(domDataState.get.call(node), undefined, 'Data should be empty');
+			assert.deepEqual(domDataState._removalDisposalMap, {}, 'should have no disposals');
 
 			domDataState.delete.call(node);
 			done();


### PR DESCRIPTION
This prevents the memory leak caused by setting up a Node removal
listener on elements in order to clean up data.

Fixes #21