### PR TITLE
Use can-dom-data as the backing for can-dom-data-state

### DIFF
--- a/can-dom-data-state.js
+++ b/can-dom-data-state.js
@@ -1,64 +1,18 @@
 'use strict';
 var namespace = require('can-namespace');
-var domMutate = require('can-dom-mutate');
 var CID = require("can-cid");
+var domData = require("can-dom-data");
 
-var isEmptyObject = function(obj){
-	/* jshint -W098 */
-	for(var prop in obj) {
-		return false;
-	}
-	return true;
-};
+var slice = [].slice;
+function unwrap(obj, key) {
+    return function() {
+	var args = slice.call(arguments, 0);
+	args.unshift(this);
+	return obj[key].apply(obj, args);
+    };
+}
 
-var data = {};
-var removedDisposalMap = {};
-
-// delete this node's `data`
-// returns true if the node was deleted.
-var deleteNode = function() {
-	var id = CID.get(this);
-	var nodeDeleted = false;
-	if(id && data[id]) {
-		nodeDeleted = true;
-		delete data[id];
-	}
-	if (removedDisposalMap[id]) {
-		removedDisposalMap[id]();
-		delete removedDisposalMap[id];
-	}
-	return nodeDeleted;
-};
-
-var setData = function(name, value) {
-	var id = CID(this);
-	var store = data[id] || (data[id] = {});
-	if (name !== undefined) {
-		store[name] = value;
-		var isNode = !!(this && typeof this.nodeType === 'number');
-		if (isNode && !removedDisposalMap[id]) {
-			var target = this;
-			removedDisposalMap[id] = domMutate.onNodeRemoval(target, function () {
-				var doc = target.ownerDocument;
-				var ownerNode = doc.contains ? doc : doc.documentElement;
-				if (!ownerNode || !ownerNode.contains(target)) {
-					setTimeout(function () {
-						deleteNode.call(target);
-					}, 13);
-				}
-			});
-		}
-	}
-	return store;
-};
-
-/*
- * Core of domData that does not depend on mutationDocument
- * This is separated in order to prevent circular dependencies
- */
 var domDataState = {
-	_data: data,
-	_removalDisposalMap: removedDisposalMap,
 
 	getCid: function() {
 		// TODO log warning! to use can-cid directly
@@ -72,26 +26,11 @@ var domDataState = {
 
 	expando: CID.domExpando,
 
-	get: function(key) {
-		var id = CID.get(this),
-			store = id && data[id];
-		return key === undefined ? store : store && store[key];
-	},
-
-	set: setData,
-
-	clean: function(prop) {
-		var id = CID.get(this);
-		var itemData = data[id];
-		if (itemData && itemData[prop]) {
-			delete itemData[prop];
-		}
-		if(isEmptyObject(itemData)) {
-			deleteNode.call(this);
-		}
-	},
-
-	delete: deleteNode
+	_data: domData._data,
+	get: unwrap(domData, "get"),
+	set: unwrap(domData, "set"),
+	clean: unwrap(domData, "clean"),
+	delete: unwrap(domData, "delete"),
 };
 
 if (namespace.domDataState) {

--- a/can-dom-data-state.js
+++ b/can-dom-data-state.js
@@ -2,6 +2,7 @@
 var namespace = require('can-namespace');
 var CID = require("can-cid");
 var domData = require("can-dom-data");
+var canDev = require("can-log/dev/dev");
 
 var slice = [].slice;
 function unwrap(obj, key) {
@@ -38,3 +39,9 @@ if (namespace.domDataState) {
 } else {
 	module.exports = namespace.domDataState = domDataState;
 }
+
+//!steal-remove-start
+if (process.env.NODE_ENV !== 'production') {
+	canDev.warn('can-dom-data-state is deprecated; please use can-dom-data instead: https://github.com/canjs/can-dom-data');
+}
+//!steal-remove-end

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "can-cid": "^1.1.0",
+    "can-dom-data": "^1.0.1",
     "can-dom-mutate": "^1.0.0",
     "can-namespace": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "can-cid": "^1.1.0",
     "can-dom-data": "^1.0.1",
     "can-dom-mutate": "^1.0.0",
+    "can-log": "^1.0.0",
     "can-namespace": "^1.0.0"
   },
   "devDependencies": {

--- a/test/memory-test.js
+++ b/test/memory-test.js
@@ -6,46 +6,6 @@ var globals = require('can-globals');
 
 unit.module('can-dom-data-state: memory');
 
-unit.test('should clean up data when a node is removed from the document', function (assert) {
-	var done = assert.async();
-	var node = document.createElement('div');
-	var slot = document.getElementById('qunit-fixture');
-
-	domDataState.set.call(node, 'foo', 'bar');
-
-	slot.appendChild(node);
-
-	var dispose = domMutate.onNodeRemoval(node, function () {
-		dispose();
-		setTimeout(function () {
-			assert.equal(domDataState.get.call(node), undefined, 'Data should be empty');
-			assert.deepEqual(domDataState._removalDisposalMap, {}, 'should have no disposals');
-
-			domDataState.delete.call(node);
-			done();
-		}, 26); // MAGIC: must be after safeguard setTimeout
-	});
-
-	slot.removeChild(node);
-});
-
-unit.test('should not setup cleanup for non-Node objects', function (assert) {
-	var notNode = {};
-	domDataState.set.call(notNode, 'foo', 'bar');
-	assert.deepEqual(domDataState._removalDisposalMap, {}, 'should have no disposals');
-
-	domDataState.delete.call(notNode);
-});
-
-unit.test('should dispose of the subscription when all data is removed from a node', function (assert) {
-	var node = document.createElement('div');
-	domDataState.set.call(node, 'foo', 'bar');
-	domDataState.clean.call(node, 'foo');
-	assert.deepEqual(domDataState._removalDisposalMap, {}, 'should have no disposals');
-
-	domDataState.delete.call(node);
-});
-
 unit.test('works if the documentElement is removed', function(assert) {
 	var done = assert.async();
 

--- a/test/storage-test.js
+++ b/test/storage-test.js
@@ -42,7 +42,7 @@ unit.test('should delete node', function () {
 	unit.equal(domDataState.get('foo'), foo);
 	unit.equal(domDataState.get('bar'), bar);
 	domDataState.delete();
-	unit.equal(domDataState._data['1'], undefined);
+	unit.equal(domDataState._data.get(domDataState), undefined);
 });
 
 unit.test('should delete all data of node', function () {
@@ -54,5 +54,5 @@ unit.test('should delete all data of node', function () {
 	domDataState.clean('bar');
 	unit.equal(domDataState.get('foo'), undefined);
 	unit.equal(domDataState.get('bar'), undefined);
-	unit.equal(domDataState._data['1'], undefined);
+	unit.equal(domDataState._data.get(domDataState), undefined);
 });


### PR DESCRIPTION
This is the first step to deprecating and removing can-dom-data-state entirely.